### PR TITLE
Add seconds to weeks converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ use ramazancetinkaya\SecondsConverter;
 $converter = new SecondsConverter();
 
 try {
-    echo $converter->convert(999999); // Output: "1 weeks, 4 days, 13 hours, 46 minutes, 39 seconds"
+    echo $converter->convert(999999); // Output: "1 week, 4 days, 13 hours, 46 minutes, 39 seconds"
 } catch (InvalidArgumentException $e) {
     echo "Error: " . $e->getMessage();
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/ramazancetinkaya/seconds-converter)](https://github.com/ramazancetinkaya/seconds-converter/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/ramazancetinkaya/seconds-converter)](https://github.com/ramazancetinkaya/seconds-converter/network)
 
-Seconds Converter is a PHP library designed to simplify the conversion of seconds into various time units such as minutes, hours, and days. It provides a convenient and easy-to-use interface for developers to integrate time conversion functionality into their projects.
+Seconds Converter is a PHP library designed to simplify the conversion of seconds into various time units such as minutes, hours, days, and weeks. It provides a convenient and easy-to-use interface for developers to integrate time conversion functionality into their projects.
 
 ## Table of Contents
 
@@ -53,7 +53,7 @@ use ramazancetinkaya\SecondsConverter;
 $converter = new SecondsConverter();
 
 try {
-    echo $converter->convert(123456); // Output: "1 days, 10 hours, 17 minutes, 36 seconds"
+    echo $converter->convert(999999); // Output: "1 weeks, 4 days, 13 hours, 46 minutes, 39 seconds"
 } catch (InvalidArgumentException $e) {
     echo "Error: " . $e->getMessage();
 }

--- a/src/SecondsConverter.php
+++ b/src/SecondsConverter.php
@@ -2,7 +2,7 @@
 /**
  * Seconds Converter
  *
- * A library to convert seconds into minutes, hours, and days.
+ * A library to convert seconds into minutes, hours, days, and weeks.
  *
  * @category Utility
  * @package  SecondsConverter
@@ -44,9 +44,19 @@ class SecondsConverter {
     public function toDays(int $seconds): float {
         return $seconds / 86400;
     }
+    
+    /**
+     * Convert seconds to weeks.
+     *
+     * @param int $seconds The number of seconds to convert.
+     * @return float The converted value in weeks.
+     */
+    public function toWeeks(int $seconds): float {
+        return $seconds / 604800;
+    }
 
     /**
-     * Convert seconds to a human-readable format (minutes, hours, days).
+     * Convert seconds to a human-readable format (minutes, hours, days, weeks).
      *
      * @param int $seconds The number of seconds to convert.
      * @return string The converted value with appropriate units.
@@ -63,6 +73,7 @@ class SecondsConverter {
 
         $output = [];
         $units = [
+            'week' => 604800,
             'day' => 86400,
             'hour' => 3600,
             'minute' => 60,


### PR DESCRIPTION
Add support to convert from seconds to weeks. A week is 7 days (86400 seconds*7=604800 seconds)